### PR TITLE
sidebar: updating sidebar classes to get rid of the horizontal scrollbar

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -286,3 +286,13 @@ body {
   right: 0;
   left: 0;
 }
+
+#sidebar-wrapper .sidebar-nav {
+  margin-left: -15px;
+  margin-right: -15px;
+}
+
+#sidebar-wrapper .sidebar-nav .row {
+  margin-left: 0px;
+  margin-right: 0px;
+}


### PR DESCRIPTION
Just adding two rules to main.css so the sidebar doesn't have a horizontal scroll bar. It was caused by Bootstrap's grid row classes and Simple Sidebar's classes pushing and pulling the elements the wrong way. I just moved the negative margins out of the rows and into the sidebar container.