### PR TITLE
sidebar: updating CSS and classes to improve layout, closes #105

### DIFF
--- a/src/html/index.html
+++ b/src/html/index.html
@@ -22,12 +22,12 @@
         href="bower_components/bootstrap/dist/css/bootstrap.min.css"
         id="theme_css">
   <link rel="stylesheet"
-        href="styles/main.css">
-
-  <link rel="stylesheet"
         href="styles/simple-sidebar.css">
   <link rel="stylesheet"
         href="bower_components/angularjs-slider/dist/rzslider.min.css" />
+  <link rel="stylesheet"
+        href="styles/main.css">
+
 
   <title>Nucleogenesis</title>
   <script>

--- a/src/html/views/sidebar.html
+++ b/src/html/views/sidebar.html
@@ -8,20 +8,22 @@
       ng-mouseover="ct.state.removeNew(key)"
       class="row">
     <get-html value="key"
-              class="col-lg-2"></get-html>
+              class="col-xs-2"></get-html>
     <pretty value="ct.state.player.resources[key].number"
-            class="col-lg-6"></pretty>
-    <span ng-if="ct.data.radioisotopes.indexOf(key) != -1"
-          class="mdi mdi-18px mdi-radioactive"></span>
-    <span ng-if="ct.state.hasNew(key)"
-          class="mdi mdi-18px mdi-alert-decagram"></span>
+            class="col-xs-6"></pretty>
+    <span class="col-xs-4 sidebar-icons">
+      <span ng-if="ct.data.radioisotopes.indexOf(key) != -1"
+            class="mdi mdi-18px mdi-radioactive"></span>
+      <span ng-if="ct.state.hasNew(key)"
+            class="mdi mdi-18px mdi-alert-decagram"></span>
+    </span>
     <ul ng-if="ct.data.radioisotopes.indexOf(key) != -1"
         class="sub-nav">
       <li class="row">
-        <span class="col-lg-2">
+        <span class="col-xs-2">
     			t<sub>1/2</sub>
     		</span>
-        <span class="col-lg-10">
+        <span class="col-xs-10">
     			<pretty value="ct.data.elements[ct.state.currentElement].isotopes[key].decay.half_life"></pretty>
     			s
     		</span>
@@ -30,13 +32,13 @@
 
           class="row">
         <span ng-if="decay.ratio !== 1"
-              class="col-lg-2">
+              class="col-xs-2">
 			    {{decay.ratio*1000/10}}%
 		    </span>
         <get-html value="type"
-                  class="col-lg-2"></get-html>
+                  class="col-xs-2"></get-html>
         <span ng-bind-html="ct.util.trustHTML(ct.format.reactionFormat(1, decay.reaction))"
-              class="col-lg-8"></span>
+              class="col-xs-8"></span>
       </li>
     </ul>
   </li>

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -290,9 +290,19 @@ body {
 #sidebar-wrapper .sidebar-nav {
   margin-left: -15px;
   margin-right: -15px;
+  padding-left: 15px;
 }
 
-#sidebar-wrapper .sidebar-nav .row {
-  margin-left: 0px;
-  margin-right: 0px;
+#sidebar-wrapper .sidebar-nav li {
+  margin-right: 0;
+  text-indent: 0;
+}
+
+#sidebar-wrapper .sidebar-nav .sidebar-brand {
+  text-align: center;
+  margin-left: -15px;
+}
+
+#sidebar-wrapper .sidebar-icons {
+  text-align: right;
 }


### PR DESCRIPTION
fix: moves main.css to highest precedence
sidebar: converts all responsive classes to x-small from large
sidebar: fixes simple-sidebar's positioning weirdness
sidebar: inserts icons into column, shifts them to right
sidebar: centers sidebar-brand text
fix: updates css to be in-line with code-climate

Went ahead and updated all the CSS. Looks the same at all widths on my end, and has about the same indentation/layout as you had mentioned in #105.